### PR TITLE
Fixed odd score bonus bug

### DIFF
--- a/src/snakes.cpp
+++ b/src/snakes.cpp
@@ -158,11 +158,12 @@ void incLen()
 
 void checkFood()
 {
-  int flag=0;
+  int flag=0, k;
   for (int i=fx-(12-level);i<=fx+(12-level);i++)
     for (int j=fy-(12-level);j<=fy+(12-level);j++)
-      if (arrx[0]==i && arry[0]==j)
-       {flag=1; break;}
+      for(k=0;k<len;k++)
+        if (arrx[k]==i && arry[k]==j)
+         {flag=1; break;}
   if (flag==1)
     {incLen(); score++; if (score%4==0) {showbonus=1;bc=1;} fc=1;}
 }
@@ -204,10 +205,11 @@ void printBonus()
 
 void checkBonus()
 {
-  int flag=0;
+  int flag=0, k;
   for (int i=bx-6;i<=bx+6;i++)
     for (int j=by-6;j<=by+6;j++)
-      if (arrx[0]==i && arry[0]==j)
+      for (k=0;k<len;k++)
+      if (arrx[k]==i && arry[k]==j)
        {flag=1; break;}
   if (flag==1)
     {incLen(); incLen();score+=2; if (score%4==0) {showbonus=1;bc=1;} showbonus=0; bc=0;}


### PR DESCRIPTION
Fixes #1 
Instead of checking if head lies in the range of food particle width, the program now checks if any part of snake passes through the food particle.